### PR TITLE
Configure `Layout/MultilineMethodCallIndentation`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,12 @@ Layout/MultilineHashKeyLineBreaks:
 Layout/MultilineMethodArgumentLineBreaks:
   Enabled: true
 
-# hecks that each parameter in a multi-line method definition starts on a
+# Checks the indentation of the method name part in method calls that span more 
+# than one line.
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
+# Checks that each parameter in a multi-line method definition starts on a
 # separate line.
 Layout/MultilineMethodParameterLineBreaks:
   Enabled: true


### PR DESCRIPTION
Aligning chained method calls to the `.` gets really bothersome on long lines and can cause a chained method call to exceed the recommended line length.

This is a simpler configuration that enforces indentation relative to the receiver:

```ruby
some_long_var_name
  .to_a
  .map(&:upcase)
```